### PR TITLE
Move test deps out of runtime; relax pytest upper bound in [dev]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,6 @@ dependencies = [
   "cobs>=1.2.1,<2.0.0",
   "numpy>=2.2.3,<3.0.0",
   "crc>=7.1.0,<8.0.0",
-  "pytest>=8.3.4,<9.0.0",
-  "pytest-cov>=6.0.0,<7.0.0",
-  "pytest-benchmark>=5.1.0,<6.0.0",
-  "scikit-build-core>=0.10.7",
-  "nanobind>=2.5.0",
   "pyserial>=3.5",
   "janus>=2.0.0",
 ]
@@ -30,9 +25,9 @@ Repository = "https://github.com/Florioo/burst-link-protocol"
 dev = [
   "scikit-build-core[pyproject]>=0.10.7,<0.11.0",
   "nanobind>=2.5.0,<3.0.0",
-  "pytest>=8.3.4,<9.0.0",
-  "pytest-cov>=6.0.0,<7.0.0",
-  "pytest-benchmark>=5.1.0,<6.0.0"
+  "pytest>=8.3.4",
+  "pytest-cov>=6.0.0",
+  "pytest-benchmark>=5.1.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- Drops `pytest`, `pytest-cov`, `pytest-benchmark`, `scikit-build-core`, and `nanobind` from `[project] dependencies` (runtime). Test/build tooling belongs in `[project.optional-dependencies] dev`.
- Removes the `<9.0.0` upper bound on `pytest` in the dev extras — was incompatible with downstream projects that need pytest 9 (notably node-hermes-core), forcing a resolution conflict that propagated through the whole Hermes workspace.

## Why
This package's runtime deps were inherited by every consumer of burst-link-protocol, which made it impossible to coexist with `pytest>=9.0.2` elsewhere. Moving them out unblocks the wider Hermes workspace from a single sync.

## Test plan
- [x] `uv build --wheel` still produces a working wheel
- [x] `uv pip install` from the resulting wheel installs without test deps
- [x] Ran in the parent Hermes workspace; `uv sync` no longer fails on pytest version conflict